### PR TITLE
Terrybonds patch 1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 machine:
   node:
+    version: 6.9.1
 
 deployment:
   staging:

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "aws-sdk": "^2.4.10",
     "express": "^4.14.0",
-    "s3o-middleware": "^1.7.0"
+    "s3o-middleware": "^1.8.0"
   },
   "engines": {
-    "node": "5.3.0"
+    "node": "6.9.1"
   }
 }


### PR DESCRIPTION
Ups the version of node and s3o middleware to 6.9.1 and 1.8 respectively.

Changes:
Will improve security, etc for node and remove the horribly short timeout of s3o.