### PR TITLE
Allow support for users to access items in Dewey without adding .html

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ app.use(function(req, res) {
 
 	// Default to index page
 	if (!key) key = "index.html";
+	if (!key.endsWith(".html")) key += ".html";
 	var params = {Bucket: deweyBucket, Key: key};
 	var stream = s3.getObject(params).createReadStream();
 	stream.on('error', function (error) {


### PR DESCRIPTION
Allow support for users to access systems in Dewey without adding .html to the URL. It's backwards compatible with URLs that *do* make use of .html already.